### PR TITLE
Respect {parseValues: false} for set_value response

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,8 +1,15 @@
 var Quorum = require('./quorum');
 var textPattern = /^text\/.*/;
 
-exports.parse = function (response, parse) {
+function parseSetValue(response, parse) {
+    if (parse) {
+        for (var key in response) {
+            response[key] = response[key].toString();
+        }
+    }
+}
 
+exports.parse = function (response, parse) {
     response = Quorum.convert(response);
 
     for (var key in response) {
@@ -25,6 +32,9 @@ exports.parse = function (response, parse) {
             else if (key !== 'vclock' && key !== 'context' && key !== 'value') {
                 response[key] = response[key].toString();
             }
+        }
+        else if (key === 'set_value') {
+            parseSetValue(response[key], parse);
         }
         else if (typeof response[key] === 'object') {
             response[key] = exports.parse(response[key], parse);


### PR DESCRIPTION
We're reading binary value from riak sets.  We need these in buffers, not strings.
