### PR TITLE
Client side request timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ ifeq ($(TEST_ENV),travis)
 	command := sudo
 	param := riak-admin
 else
-	command := riak-admin
-	param :=
+	command := sudo
+	param := riak-admin
 endif
 
 test: dt-setup

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ ifeq ($(TEST_ENV),travis)
 	command := sudo
 	param := riak-admin
 else
-	command := sudo
-	param := riak-admin
+	command := riak-admin
+	param :=
 endif
 
 test: dt-setup

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -67,10 +67,15 @@ ConnectionManager.prototype.connect = function (callback) {
 
 // Public disconnect method
 ConnectionManager.prototype.disconnect = function () {
-
-    if (this.task && this.task.callback) {
-        this._cleanup(new Error('Connection destroyed'));
+    var error = new Error('Connection destroyed');
+    if (this.task) {
+        this._cleanup(error);
     }
+    while (this.queue.length > 0) {
+        this.task = this.queue.shift();
+        this._cleanup(error);
+    }
+
     // destroy the socket, this invalidates it for the connection pool
     this.client.destroy();
 };
@@ -129,7 +134,7 @@ ConnectionManager.prototype._receive = function (data) {
         // in some cases, but has been unreproducable with a test.
         /* $lab:coverage:off$ */
         if (this.readBuf.length < this.readBufPos + data.length) {
-            this._growReadBuffer(this.readBufPos + data.length);   
+            this._growReadBuffer(this.readBufPos + data.length);
         }
         /* $lab:coverage:on$ */
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -194,8 +194,7 @@ ConnectionManager.prototype._processNext = function (callback) {
     if (this.task) {
         // Yield to IO and try again
         setImmediate(this._processNext.bind(this), callback);
-    }
-    else if (this.queue.length > 0) {
+    } else if (this.queue.length > 0) {
         this.task = this.queue.shift();
         this.send(this.task.message, callback);
     }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -66,8 +66,8 @@ ConnectionManager.prototype.connect = function (callback) {
 };
 
 // Public disconnect method
-ConnectionManager.prototype.disconnect = function () {
-    var error = new Error('Connection destroyed');
+ConnectionManager.prototype.disconnect = function (reason) {
+    var error = new Error(reason || 'Connection destroyed');
     if (this.task) {
         this._cleanup(error);
     }
@@ -173,6 +173,8 @@ ConnectionManager.prototype._cleanup = function (err, reply) {
 
     this.reply = {};
 
+    clearTimeout(this.task.timer);
+
     if (this.task.callback) {
         this.task.callback(err, reply);
     } else {
@@ -193,7 +195,7 @@ ConnectionManager.prototype._processNext = function (callback) {
         // Yield to IO and try again
         setImmediate(this._processNext.bind(this), callback);
     }
-    else {
+    else if (this.queue.length > 0) {
         this.task = this.queue.shift();
         this.send(this.task.message, callback);
     }
@@ -247,11 +249,18 @@ ConnectionManager.prototype.makeRequest = function (options, callback) {
     message.writeUInt8(riakproto.codes[options.type], 4);
     buffer.copy(message, 5);
 
+    var timer;
+    if (options.params && options.params.timeout) {
+        // On request timeout, kill the whole connection
+        timer = setTimeout(this.disconnect.bind(this, "Request timeout"), options.params.timeout);
+    }
+
     this.queue.push({
         message: message,
         callback: options.callback,
         expectMultiple: options.expectMultiple,
-        stream: options.stream
+        stream: options.stream,
+        timer: timer
     });
 
     this._processNext(callback);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "lab": "4.x.x",
     "precommit-hook": "1.x.x",
-    "jshint": "2.4.x"
+    "jshint": "2.4.x",
+    "async": "^0.9.0"
   },
   "scripts": {
     "test": "make test-cov"

--- a/test/client.js
+++ b/test/client.js
@@ -1,5 +1,7 @@
 var Lab = require('lab');
 var RiakPBC = require('../');
+var async = require('async');
+var net = require('net');
 
 var lab = exports.lab = Lab.script();
 var after = lab.after;
@@ -18,6 +20,35 @@ describe('Client', function () {
             client.ping(function (err) {
 
                 expect(err).to.exist;
+                done();
+            });
+        });
+
+        it('returns an error when request times out', function (done) {
+            var server = net.createServer();
+            server.listen(4312);
+            server.on('connection', function(socket) {
+                setTimeout(socket.end.bind(socket), 100);
+            });
+
+            var client = RiakPBC.createClient({ port: 4312, connectTimeout: 10 });
+            async.parallel([
+                function(next) {
+                    client.get({
+                        timeout: 50
+                    }, function (err) {
+                        expect(err.message).to.equal('Request timeout');
+                        next();
+                    });
+                },
+                function(next) {
+                    client.ping(function (err) {
+                        expect(err.message).to.equal('Request timeout');
+                        next();
+                    });
+                }
+            ], function() {
+                server.close();
                 done();
             });
         });

--- a/test/client.js
+++ b/test/client.js
@@ -27,13 +27,13 @@ describe('Client', function () {
         it('returns an error when request times out', function (done) {
             var server = net.createServer();
             server.listen(4312);
-            server.on('connection', function(socket) {
+            server.on('connection', function (socket) {
                 setTimeout(socket.end.bind(socket), 100);
             });
 
             var client = RiakPBC.createClient({ port: 4312, connectTimeout: 10 });
             async.parallel([
-                function(next) {
+                function (next) {
                     client.get({
                         timeout: 50
                     }, function (err) {
@@ -41,13 +41,13 @@ describe('Client', function () {
                         next();
                     });
                 },
-                function(next) {
+                function (next) {
                     client.ping(function (err) {
                         expect(err.message).to.equal('Request timeout');
                         next();
                     });
                 }
-            ], function() {
+            ], function () {
                 server.close();
                 done();
             });


### PR DESCRIPTION
1. On disconnect, trigger cleanup of all tasks in the queue also.

2. Set a timer when making a request for the request timeout. This timer will trigger a disconnect (thus calling back all tasks waiting with a "Request timeout" error).

It's tricky to avoid throwing away the whole connection on a request timeout since requests are pipelined. If there is a request timeout, it's likely that there's something wrong with the connection anyway.

@markyen @fourk @countrodrigo @Raynos 