### PR TITLE
Make sure to call the send callback when firing the request timeout

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -255,7 +255,7 @@ ConnectionManager.prototype._processMessage = function (data) {
 
 // ConnectionManager.prototype.makeRequest = function (type, data, callback, expectMultiple, streaming) {
 ConnectionManager.prototype.makeRequest = function (options, callback) {
-
+    var self = this;
     var buffer, message;
 
     if (riakproto.messages[options.type]) {
@@ -269,10 +269,21 @@ ConnectionManager.prototype.makeRequest = function (options, callback) {
     message.writeUInt8(riakproto.codes[options.type], 4);
     buffer.copy(message, 5);
 
+    var calledBack;
+    function callbackOnce() {
+        if (!calledBack) {
+            calledBack = true;
+            callback();
+        }
+    }
+
     var timer;
     if (options.params && options.params.timeout) {
         // On request timeout, kill the whole connection
-        timer = setTimeout(this.disconnect.bind(this, "Request timeout"), options.params.timeout);
+        timer = setTimeout(function onReqTimout() {
+            self.disconnect("Request timeout");
+            callbackOnce();
+        }, options.params.timeout);
     }
 
     this.queue.push({
@@ -283,7 +294,7 @@ ConnectionManager.prototype.makeRequest = function (options, callback) {
         timer: timer
     });
 
-    this._processNext(callback);
+    this._processNext(callbackOnce);
 };
 
 module.exports = ConnectionManager;


### PR DESCRIPTION
This callback is absolutely necessary to call as it releases the connection back to the pool.
@kumikoda @Raynos 
